### PR TITLE
FIT-21: Store user id in JWT

### DIFF
--- a/src/main/java/com/fittracker/fittracker/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fittracker/fittracker/security/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.fittracker.fittracker.security;
 
-import com.fittracker.fittracker.entity.UserDetails;
-import com.fittracker.fittracker.service.UserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -26,12 +25,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final int TOKEN_BEGIN_INDEX = 7;
 
     private final JwtUtils jwtUtils;
-    private final UserDetailsService userDetailsService;
 
     @Autowired
-    public JwtAuthenticationFilter(JwtUtils jwtUtils, UserDetailsService userDetailsService) {
+    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
         this.jwtUtils = jwtUtils;
-        this.userDetailsService = userDetailsService;
     }
 
     @Override
@@ -53,9 +50,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthenticationInSecurityContext(HttpServletRequest request, String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(jwtUtils.getUsernameFromToken(token));
+        UUID uuid = jwtUtils.getUserIdFromToken(token);
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                userDetails.id(), userDetails.getPassword(), List.of());
+                uuid, "", List.of());
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);

--- a/src/main/java/com/fittracker/fittracker/security/JwtUtils.java
+++ b/src/main/java/com/fittracker/fittracker/security/JwtUtils.java
@@ -53,8 +53,12 @@ public class JwtUtils {
     }
 
     public UUID getUserIdFromToken(String token) {
-        Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
-        return UUID.fromString(claims.get("userId", String.class));
+        return UUID.fromString(Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("userId", String.class));
     }
 
 

--- a/src/main/java/com/fittracker/fittracker/security/JwtUtils.java
+++ b/src/main/java/com/fittracker/fittracker/security/JwtUtils.java
@@ -1,6 +1,8 @@
 package com.fittracker.fittracker.security;
 
 import com.fittracker.fittracker.config.JwtConfig;
+import com.fittracker.fittracker.entity.UserDetails;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtils {
@@ -30,7 +33,9 @@ public class JwtUtils {
         Date dateNow = new Date();
         Date expirationDate = new Date(dateNow.getTime() + tokenExpirationPeriodMilliseconds);
 
+
         return Jwts.builder()
+                .claim("userId",((UserDetails) authentication.getPrincipal()).id())
                 .subject(authentication.getName())
                 .issuedAt(dateNow)
                 .expiration(expirationDate)
@@ -46,6 +51,12 @@ public class JwtUtils {
                 .getPayload()
                 .getSubject();
     }
+
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+        return UUID.fromString(claims.get("userId", String.class));
+    }
+
 
     public boolean isTokenValid(String token) {
         try {

--- a/src/test/java/com/fittracker/fittracker/security/JwtUtilsTest.java
+++ b/src/test/java/com/fittracker/fittracker/security/JwtUtilsTest.java
@@ -1,6 +1,7 @@
 package com.fittracker.fittracker.security;
 
 import com.fittracker.fittracker.config.JwtConfig;
+import com.fittracker.fittracker.entity.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 
@@ -16,17 +19,22 @@ import static org.mockito.Mockito.lenient;
 class JwtUtilsTest {
 
     private static final String TEST_SECRET = "3Wlamn5wuIm2698NNKnplSq2GY8vqbzBCRynuvh1swOKzp5Ivr1zaQ9seoEyk5mFNEyvkxvU9pExIqdm";
+    private static final UUID testUUID = UUID.fromString("5ed73615-eea8-493e-b406-393f3b0af4aa");
     private static final int JWT_SIGNATURE_LENGTH = 86;
     private static final int TEST_TOKEN_EXPIRATION_PERIOD_MINUTES = 60;
     @Mock
     private Authentication authentication;
+    @Mock
+    private UserDetails userDetails;
     private JwtUtils jwtUtils;
-
     private JwtConfig jwtConfig;
+
 
     @BeforeEach
     public void beforeEach() {
         lenient().when(authentication.getName()).thenReturn("user");
+        lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
+        lenient().when(userDetails.id()).thenReturn(testUUID);
         jwtConfig = new JwtConfig(TEST_SECRET, TEST_TOKEN_EXPIRATION_PERIOD_MINUTES);
         jwtUtils = new JwtUtils(jwtConfig);
     }
@@ -48,6 +56,14 @@ class JwtUtilsTest {
         var result = jwtUtils.getUsernameFromToken(token);
 
         assertThat(result).isEqualTo("user");
+    }
+
+    @Test
+    void getUserIdFromToken_givenToken_shouldReturnUserId() {
+        var token = jwtUtils.generateToken(authentication);
+        var result = jwtUtils.getUserIdFromToken(token);
+
+        assertThat(result).isEqualTo(testUUID);
     }
     @Nested
     class IsTokenValid {


### PR DESCRIPTION
1. I tried to evade adding `authenticationService` to `WeightControllerIntegrationTest` but as UUID is granted by a database I had no control over UUID and as long a JWT token contains this UUID it has to be generated every time a test is run.