### PR TITLE
FIT-40: Sort weights by date

### DIFF
--- a/src/main/java/com/fittracker/fittracker/repository/WeightRepository.java
+++ b/src/main/java/com/fittracker/fittracker/repository/WeightRepository.java
@@ -13,5 +13,5 @@ public interface WeightRepository extends CrudRepository<Weight, Long> {
 
     Optional<Weight> findByDateAndUserId(LocalDate date, UUID userId);
 
-    List<Weight> findByDateBetweenAndUserId(LocalDate startDate, LocalDate endDate, UUID userId);
+    List<Weight> findByDateBetweenAndUserIdOrderByDate(LocalDate startDate, LocalDate endDate, UUID userId);
 }

--- a/src/main/java/com/fittracker/fittracker/service/WeightService.java
+++ b/src/main/java/com/fittracker/fittracker/service/WeightService.java
@@ -59,7 +59,7 @@ public class WeightService {
             throw new InvalidDateRangeException();
         }
 
-        return weightRepository.findByDateBetweenAndUserId(startDate, endDate, SecurityHelper.getUserId())
+        return weightRepository.findByDateBetweenAndUserIdOrderByDate(startDate, endDate, SecurityHelper.getUserId())
             .stream()
             .map(WeightResponse::fromWeight)
             .toList();

--- a/src/test/java/com/fittracker/fittracker/controller/WeightControllerIntegrationTest.java
+++ b/src/test/java/com/fittracker/fittracker/controller/WeightControllerIntegrationTest.java
@@ -134,14 +134,14 @@ public class WeightControllerIntegrationTest extends BaseIntegrationTest {
             public void beforeEach() {
                 List<Weight> weights = List.of(
                     new Weight(LocalDate.of(2023, 1, 1), 100.0, testUuid),
-                    new Weight(LocalDate.of(2023, 1, 10), 95.5, testUuid),
-                    new Weight(LocalDate.of(2023, 2, 20), 98.2, testUuid)
+                    new Weight(LocalDate.of(2023, 2, 20), 98.2, testUuid),
+                    new Weight(LocalDate.of(2023, 1, 10), 95.5, testUuid)
                 );
                 weightRepository.saveAll(weights);
             }
 
             @Test
-            void givenDateRange_shouldReturnListOfWeightResponses() throws Exception {
+            void givenDateRange_shouldReturnListOfWeightResponsesSortedByDate() throws Exception {
                 mockMvc.perform(get(URI.create(ENDPOINT + "s?startDate=2023-01-02&endDate=2023-03-04"))
                         .header("Authorization", "Bearer " + token))
                     .andExpect(status().isOk())

--- a/src/test/java/com/fittracker/fittracker/service/WeightServiceTest.java
+++ b/src/test/java/com/fittracker/fittracker/service/WeightServiceTest.java
@@ -205,26 +205,26 @@ public class WeightServiceTest {
 
         @Test
         void givenValidDateRange_shouldReturnListOfWeightResponses() {
-            when(weightRepository.findByDateBetweenAndUserId(any(), any(), any()))
+            when(weightRepository.findByDateBetweenAndUserIdOrderByDate(any(), any(), any()))
                 .thenReturn(List.of(weight(), endWeight));
 
             var expected = List.of(weightResponse(), weightResponseWithDate(endDate));
             var result = weightService.findByDateRange(TEST_DATE, endDate);
 
             assertThat(result).isEqualTo(expected);
-            verify(weightRepository).findByDateBetweenAndUserId(TEST_DATE, endDate, TEST_UUID);
+            verify(weightRepository).findByDateBetweenAndUserIdOrderByDate(TEST_DATE, endDate, TEST_UUID);
             verifyNoMoreInteractions(weightRepository);
         }
 
         @Test
         void givenValidDateRangeWithNoWeights_shouldReturnEmptyList() {
-            when(weightRepository.findByDateBetweenAndUserId(any(), any(), any()))
+            when(weightRepository.findByDateBetweenAndUserIdOrderByDate(any(), any(), any()))
                 .thenReturn(List.of());
 
             var result = weightService.findByDateRange(TEST_DATE, endDate);
 
             assertThat(result).isEmpty();
-            verify(weightRepository).findByDateBetweenAndUserId(TEST_DATE, endDate, TEST_UUID);
+            verify(weightRepository).findByDateBetweenAndUserIdOrderByDate(TEST_DATE, endDate, TEST_UUID);
 
             verifyNoMoreInteractions(weightRepository);
         }


### PR DESCRIPTION
Couldn't replicate list being retrieved unsorted. Added OrderByDate clause to WeightRepository as I can't show 100% cause of list being sorted.